### PR TITLE
Improved Migrate on OSX as it was trying to process DS_Store system files and failing

### DIFF
--- a/lib/migrate/migrator.js
+++ b/lib/migrate/migrator.js
@@ -10,6 +10,8 @@ var utils = require('../utils');
 
 var npdynamodb = require('../npdynamodb');
 
+var migration_suffix = '.js'
+
 function create(npd){
   return function(){
     return new Migrator(npd);
@@ -124,8 +126,11 @@ MigrateRunner.prototype.run = function(){
 
       var incompletePaths = dirs.filter(function(dir){
         var version = dir.split('_')[0];
-        if(!_.contains(versions, parseInt(version))) {
-          return dir;
+        if (version == parseInt(version)
+            && dir.indexOf(migration_suffix, dir.length - migration_suffix.length) !== -1){
+          if(!_.contains(versions, parseInt(version))) {
+            return dir;
+          }
         }
       });
 


### PR DESCRIPTION
Improved Migrate on OSX as it was trying to process DS_Store system files and failing. By checking that the 'version' component of the dir is actually a number, DS_Store files are ignored and migrate continues successfully. You might also consider checking that files have a '.js' suffix too before trying to process them.
