### PR TITLE
Set default apiVersion

### DIFF
--- a/lib/npdynamodb.js
+++ b/lib/npdynamodb.js
@@ -12,7 +12,7 @@ function npdynamodb(clients, options){
 }
 
 module.exports = function(dynamodb, options){
-  var v = dynamodb.config.apiVersion,
+  var v = dynamodb.config.apiVersion || '2012-08-10',
     api = require('./dialects/' + v + '/' + 'api')
   ;
 


### PR DESCRIPTION
Since we only support one dialect, it would not be wise to provide it as a default?