### PR TITLE
Creating "Pay per request" as default BillingMode unless otherwise specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .DS_Store
 npdfile.js
 examples
+.vscode/

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ module.exports = {
   development: {
     dynamoClient: dynamodb,
     migrations: {
-      ProvisionedThroughput: [10, 10],
+      // Omitting ProvisionedThroughput will default to on-demand
       tableName: 'npd_migrations'
     }
   },
@@ -481,6 +481,7 @@ exports.up = function(migrator){
       t.string('room_id').hashKey();
       t.number('user_id').rangeKey();
       t.projectionTypeAll(); //default is NONE
+      // Not specifying `.provisionedThroughput` will default to on-demand
     });
   });
 };

--- a/lib/migrate/migrator.js
+++ b/lib/migrate/migrator.js
@@ -117,7 +117,11 @@ MigrateRunner.prototype._createMigrateTableIfNotExits = function(){
 
     return self.migrator().createTable(tableName, function(t){
       t.number('version').hashKey();
-      t.provisionedThroughput.apply(t, self.config.migrations.ProvisionedThroughput);
+
+      // Will use default on-demand setup if no ProvisionedThroughput is defined
+      if (self.config.migrations.ProvisionedThroughput) {
+        t.provisionedThroughput.apply(t, self.config.migrations.ProvisionedThroughput);
+      }
     })
     .then(function(){
       return self.npd().rawClient().waitFor('tableExists', {TableName: tableName});

--- a/lib/migrate/migrator.js
+++ b/lib/migrate/migrator.js
@@ -26,7 +26,10 @@ Migrator.prototype.createTable = function(tableName, callback){
   var query = this.npd();
   var builder = new SchemaBuilder({
     apiVer: query.apiVersion,
-    tableName: tableName
+    tableName: tableName,
+    tableInfo: {
+      BillingMode: 'PAY_PER_REQUEST',
+    }
   });
 
   callback(builder);

--- a/lib/schema/builder.js
+++ b/lib/schema/builder.js
@@ -99,7 +99,10 @@ SchemaBuilder.prototype.globalSecondaryIndex = function(indexName, callback){
   callback(this.__newBuilder({
     IndexType: Schema.IndexType.GSI,
     tableInfo: {
-      IndexName: indexName
+      IndexName: indexName,
+      Projection: {
+        ProjectionType: 'NONE'
+      }
     }
   }));
 };
@@ -142,7 +145,10 @@ SchemaBuilder.prototype.localSecondaryIndex = function(indexName, callback){
   var def = this.__newBuilder({
     IndexType: Schema.IndexType.LSI,
     tableInfo: {
-      IndexName: indexName
+      IndexName: indexName,
+      Projection: {
+        ProjectionType: 'NONE'
+      }
     }
   });
 
@@ -184,11 +190,7 @@ function Schema(options){
   this.IndexType = Schema.IndexType.DEFAULT;
 
   this.tableInfo = options.withoutDefaultTableInfo ? {} : {
-    IndexName: null,
-    BillingMode: 'PAY_PER_REQUEST',
-    Projection: {
-      ProjectionType: 'NONE'
-    }
+    IndexName: null
   };
 
   this.mergeProps(options);

--- a/lib/schema/builder.js
+++ b/lib/schema/builder.js
@@ -44,8 +44,10 @@ SchemaBuilder.prototype._definePropsIfNotExists = function(propName){
 };
 
 SchemaBuilder.prototype.provisionedThroughput = function(r, w){
-  this._definePropsIfNotExists('BillingMode');
-  this._schema.tableInfo.BillingMode = 'PROVISIONED';
+  // Only set billing mode to 'PROVISIONED' if the propertiy was specified
+  if (this._schema.tableInfo.BillingMode) {
+    this._schema.tableInfo.BillingMode = 'PROVISIONED';
+  }
 
   this._definePropsIfNotExists('ProvisionedThroughput');
   this._schema.tableInfo.ProvisionedThroughput.ReadCapacityUnits = r;

--- a/lib/schema/builder.js
+++ b/lib/schema/builder.js
@@ -44,6 +44,9 @@ SchemaBuilder.prototype._definePropsIfNotExists = function(propName){
 };
 
 SchemaBuilder.prototype.provisionedThroughput = function(r, w){
+  this._definePropsIfNotExists('BillingMode');
+  this._schema.tableInfo.BillingMode = 'PROVISIONED';
+
   this._definePropsIfNotExists('ProvisionedThroughput');
   this._schema.tableInfo.ProvisionedThroughput.ReadCapacityUnits = r;
   this._schema.tableInfo.ProvisionedThroughput.WriteCapacityUnits = w;
@@ -182,10 +185,7 @@ function Schema(options){
 
   this.tableInfo = options.withoutDefaultTableInfo ? {} : {
     IndexName: null,
-    ProvisionedThroughput: {
-      ReadCapacityUnits: 10,
-      WriteCapacityUnits: 10
-    },
+    BillingMode: 'PAY_PER_REQUEST',
     Projection: {
       ProjectionType: 'NONE'
     }

--- a/test/data/test_tables.js
+++ b/test/data/test_tables.js
@@ -12,6 +12,7 @@ exports.compex_table = {
     { AttributeName: 'range_key', KeyType: 'RANGE' }
   ],
   TableName: 'complex_table',
+  BillingMode: 'PROVISIONED',
   ProvisionedThroughput: {
     ReadCapacityUnits: 100, WriteCapacityUnits: 100
   },


### PR DESCRIPTION
Since the last release of this project, DynamoDB now supports a new billing mode of "Pay Per Request", which sets your DynamoDB table as [on-demand](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html). Previously the default setup was to create a Table with a provisioned throughput of 10. If you are creating multiple tables (especially for testing purposes), this can increase your AWS costs significantly. You can read more about this change [here](https://aws.amazon.com/blogs/aws/amazon-dynamodb-on-demand-no-capacity-planning-and-pay-per-request-pricing/)

This check-in will set default table creation as [PAY_PER_REQUEST](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateTable.html) unless `provisionedThroughput` is called.

Code Changes
- On default table schema generation, set the `BillingMode` attribute to `PAY_PER_REQUEST`, which will set the read/write capacity mode of the table to [on-demand](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#createTable-property) by default
- When calling the `.provisionedThroughput` or setting the `ProvisionedThroughput` attribute on migration table creation, we set the `BillingMode` back to `PROVISIONED`
- Update default schema setup to prevent using the same config for both secondary index and table creation and not provide a BillingMode unless one is specified (i.e. it is only set when creating a table)
- Update test to support new BillingMode