### PR TITLE
Update supported node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 sudo: required
 language: node_js
 node_js:
-  - "4"
-  - "5"
-  - "6"
-  - "7"
   - "8"
+  - "10"
+  - "12"
+  - "13"
   - "node"
   - "lts/*"
 


### PR DESCRIPTION
node v4, v5, v6, and v7 are [end-of-life and no longer supported](https://github.com/nodejs/Release#end-of-life-releases).

node v10, v12, and v13 are [actively supported](https://nodejs.org/en/about/releases/).